### PR TITLE
Agregado método "validar()" al objeto que devuelve el plugin

### DIFF
--- a/example/ejemplo.html
+++ b/example/ejemplo.html
@@ -135,13 +135,16 @@
 
         $(function () {
 
+            var cedula = $("#Cedula").SDQ("cedula"),
+                rnc = $("#RNC").SDQ("rnc"),
+                ncf = $("#ComprobanteFiscal").SDQ("ncf");
+
             $("#ValidarCedula").click(function () {
-                var entrada = $("#Cedula").val();
                 var msgSpan = $(this).parent().find(".validationMessage")
                                      .removeClass("label-important")
                                      .removeClass("label-success");
 
-                if ($.SDQ.validarCedula(entrada)) {
+                if (cedula.validar()) {
                     msgSpan.addClass("").text("Cédula válida").addClass("label-success");
                 } else{
                     msgSpan.addClass("").text("No es una cédula!").addClass("label-important");
@@ -150,12 +153,11 @@
             });
 
             $("#ValidarRNC").click(function(){
-                var entrada = $("#RNC").val();
                 var msgSpan = $(this).parent().find(".validationMessage")
                         .removeClass("label-important")
                         .removeClass("label-success");
 
-                if ($.SDQ.validarRNC(entrada)) {
+                if (rnc.validar()) {
                     msgSpan.addClass("").text("RNC válido").addClass("label-success");
                 } else{
                     msgSpan.addClass("").text("Seguro que esto es un RNC? no parece!").addClass("label-important");
@@ -164,18 +166,15 @@
             });
 
             $("#ValidarComprobante").click(function(){
-                var entrada = $("#ComprobanteFiscal").val();
                 var msgSpan = $(this).parent().find(".validationMessage")
                         .removeClass("label-important")
                         .removeClass("label-success");
-                if ($.SDQ.validarNCF(entrada)) {
+                if (ncf.validar()) {
                     msgSpan.addClass("").text("Comprobante OK").addClass("label-success");
                 } else{
                     msgSpan.addClass("").text("Comprobante not OK!").addClass("label-important");
                 };
             });
-
-            $("#Cedula").SDQ("cedula");
         });
     </script>
 </body>

--- a/src/jquery.sdq.js
+++ b/src/jquery.sdq.js
@@ -144,25 +144,49 @@
 
         methods = {
             cedula: function (options) {
-                this.on('keypress', soloNumeros);
-                this.on('keypress', formatCedula);
-                this.on('paste', antiPaste);
-                return this;
+                var self = this;
+                self.on('keypress', soloNumeros);
+                self.on('keypress', formatCedula);
+                self.on('paste', antiPaste);
+
+                self.validar = function () {
+                    return $.SDQ.validarCedula(self.val());
+                };
+
+                return self;
             },
             rnc: function (options) {
-                this.on('keypress', soloNumeros);
-                //this.on('keypress', formatCedula);
-                this.on('paste', antiPaste);
-                return this;
+                var self = this;
+                self.on('keypress', soloNumeros);
+                //self.on('keypress', formatCedula);
+                self.on('paste', antiPaste);
+                
+                self.validar = function () {
+                    return $.SDQ.validarRNC(self.val());
+                };
+
+                return self;
             },
             nss: function (options) {
-                this.on('keypress', soloNumeros);
-                //this.on('keypress', formatCedula);
-                this.on('paste', antiPaste);
-                return this;
+                var self = this;
+                self.on('keypress', soloNumeros);
+                //self.on('keypress', formatCedula);
+                self.on('paste', antiPaste);
+                
+                self.validar = function () {
+                    return $.SDQ.validarNSS(self.val());
+                };
+
+                return self;
             },
             ncf: function (options){
-                return this;
+                var self = this;
+
+                self.validar = function () {
+                    return $.SDQ.validarNCF(self.val());
+                };
+
+                return self;
             }
         },
 


### PR DESCRIPTION
Se agrego un método "validar()" al objeto que devuelve el plugin, de
esta forma es mas natural la validación. Ej:

var cedula = $("#Cedula").SDQ("cedula");
if(cedula.validar()) {
console.log("Cédula válida");
} else {
console.log("Not valid :(");
}
